### PR TITLE
Get away from master/slave words

### DIFF
--- a/Employer/admin.py
+++ b/Employer/admin.py
@@ -3,8 +3,8 @@ from django.contrib import admin
 from .models import (
     Contact,
     CompanyInfo,
-    IndustryTypeMaster,
-    IndustryTypeSlave,
+    IndustryTypeMain,
+    IndustryTypeSubordinate,
     Division,
     District,
     Thana,
@@ -33,15 +33,15 @@ class CompanyInfoAdmin(admin.ModelAdmin):
     list_display = ['name', 'b_name', 'thana', 'address', 'business_description', 'user']
 
 
-# industry type master table
-@admin.register(IndustryTypeMaster)
-class IndustrytypemasterAdmin(admin.ModelAdmin):
+# industry type main table
+@admin.register(IndustryTypeMain)
+class IndustrytypemainAdmin(admin.ModelAdmin):
     list_display = ['name']
 
 
-# IndustryTypeSlave table
-@admin.register(IndustryTypeSlave)
-class IndustrytypeslaveAdmin(admin.ModelAdmin):
+# IndustryTypeSubordinate table
+@admin.register(IndustryTypeSubordinate)
+class IndustrytypesubordinateAdmin(admin.ModelAdmin):
     list_display = ['name']
 
 

--- a/Employer/forms.py
+++ b/Employer/forms.py
@@ -36,5 +36,5 @@ class CompanyInfoForm(forms.ModelForm):
     class Meta:
         model = CompanyInfo
         fields = ['name', 'b_name', 'country', 'thana', 'address', 'b_address', 'business_description',
-                  'industry_type_slave', 'licence_no', 'websiteurl']
+                  'industry_type_subordinate', 'licence_no', 'websiteurl']
         exclude = ['user']

--- a/Employer/migrations/0001_initial.py
+++ b/Employer/migrations/0001_initial.py
@@ -29,7 +29,7 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
-            name='IndustryTypeMaster',
+            name='IndustryTypeMain',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=200)),
@@ -44,11 +44,11 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
-            name='IndustryTypeSlave',
+            name='IndustryTypeSubordinate',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=200)),
-                ('industry_type_master', models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, to='Employer.IndustryTypeMaster')),
+                ('industry_type_main', models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, to='Employer.IndustryTypeMain')),
             ],
         ),
         migrations.AddField(
@@ -79,7 +79,7 @@ class Migration(migrations.Migration):
                 ('business_description', models.TextField()),
                 ('licence_no', models.IntegerField()),
                 ('websiteurl', models.URLField(max_length=350)),
-                ('industry_type_slave', models.ManyToManyField(to='Employer.IndustryTypeSlave')),
+                ('industry_type_subordinate', models.ManyToManyField(to='Employer.IndustryTypeSubordinate')),
                 ('thana', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='Employer.Thana')),
                 ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],

--- a/Employer/migrations/0003_auto_20200609_1340.py
+++ b/Employer/migrations/0003_auto_20200609_1340.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterField(
             model_name='companyinfo',
-            name='industry_type_slave',
-            field=models.ManyToManyField(blank=True, null=True, to='Employer.IndustryTypeSlave'),
+            name='industry_type_subordinate',
+            field=models.ManyToManyField(blank=True, null=True, to='Employer.IndustryTypeSubordinate'),
         ),
     ]

--- a/Employer/models.py
+++ b/Employer/models.py
@@ -45,16 +45,16 @@ class Thana(models.Model):
         return self.name
 
 
-class IndustryTypeMaster(models.Model):
+class IndustryTypeMain(models.Model):
     name = models.CharField(max_length=200)
 
     def __str__(self):
         return self.name
 
 
-class IndustryTypeSlave(models.Model):
+class IndustryTypeSubordinate(models.Model):
     name = models.CharField(max_length=200)
-    industry_type_master = models.ForeignKey(IndustryTypeMaster, on_delete=models.CASCADE, null=True)
+    industry_type_main = models.ForeignKey(IndustryTypeMain, on_delete=models.CASCADE, null=True)
 
     def __str__(self):
         return self.name
@@ -67,7 +67,7 @@ class CompanyInfo(models.Model):
     thana = models.ForeignKey(Thana, on_delete=models.CASCADE)
     address = models.TextField()
     b_address = models.TextField()
-    industry_type_slave = models.ManyToManyField(IndustryTypeSlave, null=True, blank=True)
+    industry_type_subordinate = models.ManyToManyField(IndustryTypeSubordinate, null=True, blank=True)
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     business_description = models.TextField()
     licence_no = models.IntegerField()
@@ -79,8 +79,8 @@ class CompanyInfo(models.Model):
     def thana_name(self):
         return self.thana.name
 
-    def industry_type_slave_name(self):
-        return self.industry_type_slave.name
+    def industry_type_subordinate_name(self):
+        return self.industry_type_subordinate.name
 
-    def get_industry_type_slave(self):
-        return ",".join([str(p) for p in self.industry_type_slave.all()])
+    def get_industry_type_subordinate(self):
+        return ",".join([str(p) for p in self.industry_type_subordinate.all()])


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.